### PR TITLE
Add validations and implement proofs upload endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+backend/node_modules/
+.env
+.env.*
+npm-debug.log*

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import profiles from './routes/profiles';
 import feed from './routes/feed';
 import swipes from './routes/swipes';
 import matches from './routes/matches';
+import proofs from './routes/proofs';
 
 const app = express();
 app.use(cors());
@@ -30,4 +31,5 @@ app.use('/api/profiles', profiles);
 app.use('/api/feed', feed);
 app.use('/api/swipes', swipes);
 app.use('/api/matches', matches);
+app.use('/api/proofs', proofs);
 app.listen(port, () => console.log(`API on http://localhost:${port}`));

--- a/backend/src/routes/profiles.ts
+++ b/backend/src/routes/profiles.ts
@@ -3,16 +3,134 @@ import { supabase } from '../services/db';
 import { randomUUID } from 'crypto';
 import { auth } from '../middleware/auth';
 
+type OnboardPayload = {
+  email?: string;
+  name: string;
+  birthdate?: string | null;
+  gender: 'male' | 'female' | 'other';
+  show_me: 'male' | 'female' | 'everyone';
+  bio?: string | null;
+  interests?: string[] | null;
+  photo_url?: string | null;
+};
+
+function parseOnboardPayload(body: any): OnboardPayload {
+  if (!body || typeof body !== 'object') {
+    throw new Error('invalid payload');
+  }
+
+  const errors: string[] = [];
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (name.length < 2) {
+    errors.push('name must have at least 2 characters');
+  }
+
+  const emailRaw = typeof body.email === 'string' ? body.email.trim() : '';
+  let email: string | undefined;
+  if (emailRaw) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(emailRaw.toLowerCase())) {
+      errors.push('email must be valid');
+    } else {
+      email = emailRaw.toLowerCase();
+    }
+  }
+
+  const allowedGenders = new Set(['male', 'female', 'other']);
+  const allowedShow = new Set(['male', 'female', 'everyone']);
+
+  const gender = typeof body.gender === 'string' ? (body.gender as string) : '';
+  if (!allowedGenders.has(gender)) {
+    errors.push('gender must be one of male, female or other');
+  }
+
+  const showMe = typeof body.show_me === 'string' ? (body.show_me as string) : '';
+  if (!allowedShow.has(showMe)) {
+    errors.push('show_me must be one of male, female or everyone');
+  }
+
+  let birthdate: string | null | undefined = undefined;
+  if (body.birthdate != null) {
+    if (typeof body.birthdate !== 'string' || !body.birthdate.trim()) {
+      errors.push('birthdate must be a string');
+    } else {
+      birthdate = body.birthdate.trim();
+    }
+  }
+
+  let bio: string | null | undefined = undefined;
+  if (body.bio != null) {
+    if (typeof body.bio !== 'string') {
+      errors.push('bio must be a string');
+    } else if (body.bio.length > 500) {
+      errors.push('bio must be at most 500 characters');
+    } else {
+      bio = body.bio;
+    }
+  }
+
+  let interests: string[] | null | undefined = undefined;
+  if (body.interests != null) {
+    if (!Array.isArray(body.interests)) {
+      errors.push('interests must be an array of strings');
+    } else {
+      const parsedInterests = body.interests.filter((item: any) => typeof item === 'string' && item.trim());
+      interests = parsedInterests.length ? parsedInterests : null;
+    }
+  }
+
+  let photoUrl: string | null | undefined = undefined;
+  if (body.photo_url != null) {
+    if (typeof body.photo_url !== 'string' || !body.photo_url.trim()) {
+      errors.push('photo_url must be a string');
+    } else {
+      photoUrl = body.photo_url.trim();
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(errors[0]);
+  }
+
+  return {
+    email,
+    name,
+    birthdate: birthdate ?? null,
+    gender: gender as OnboardPayload['gender'],
+    show_me: showMe as OnboardPayload['show_me'],
+    bio: bio ?? null,
+    interests: interests ?? null,
+    photo_url: photoUrl ?? null,
+  };
+}
+
 const r = Router();
 
 r.post('/onboard', async (req, res) => {
-  const { email, name, birthdate, gender, show_me, bio, interests, photo_url } = req.body || {};
-  if (!name) return res.status(400).json({ error: 'name required' });
+  let payload: OnboardPayload;
+  try {
+    payload = parseOnboardPayload(req.body);
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || 'invalid payload' });
+  }
 
   const token = randomUUID();
   const { data, error } = await supabase
     .from('profiles')
-    .insert([{ auth_token: token, email, name, birthdate, gender, show_me, bio, interests, photo_url }])
+    .insert([
+      {
+        auth_token: token,
+        email: payload.email,
+        name: payload.name,
+        birthdate: payload.birthdate,
+        gender: payload.gender,
+        show_me: payload.show_me,
+        bio: payload.bio,
+        interests: payload.interests,
+        photo_url: payload.photo_url,
+      },
+    ])
     .select('*')
     .single();
 

--- a/backend/src/routes/proofs.ts
+++ b/backend/src/routes/proofs.ts
@@ -1,0 +1,110 @@
+import { Router } from 'express';
+import { auth } from '../middleware/auth';
+import { parseMultipartFormData } from '../utils/multipart';
+import { supabase } from '../services/db';
+
+const MAX_UPLOAD_SIZE = 6 * 1024 * 1024; // 6MB
+const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']);
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+const r = Router();
+r.use(auth);
+
+r.post('/', async (req, res) => {
+  let form;
+  try {
+    form = await parseMultipartFormData(req);
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || 'could not parse form-data' });
+  }
+
+  const file = form.files['file'];
+  if (!file) {
+    return res.status(400).json({ error: 'missing file field' });
+  }
+
+  if (file.size <= 0) {
+    return res.status(400).json({ error: 'file is empty' });
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE) {
+    return res.status(400).json({ error: 'file too large (limit 6MB)' });
+  }
+
+  const mime = file.contentType.toLowerCase();
+  if (!ALLOWED_MIME.has(mime)) {
+    return res.status(400).json({ error: 'unsupported file type' });
+  }
+
+  const me = (req as any).userId as string;
+  const timestamp = Date.now();
+  const safeName = sanitizeFilename(file.filename || 'proof');
+  const filePath = `${me}/${timestamp}-${safeName}`;
+
+  const storage = supabase.storage.from('proofs');
+  const { error: uploadError } = await storage.upload(filePath, file.data, {
+    contentType: mime,
+    upsert: true,
+  });
+
+  if (uploadError) {
+    return res.status(400).json({ error: uploadError.message });
+  }
+
+  const { data: publicUrlData } = storage.getPublicUrl(filePath);
+  const publicUrl = publicUrlData?.publicUrl ?? null;
+
+  const { data, error } = await supabase
+    .from('proofs')
+    .upsert(
+      {
+        profile_id: me,
+        file_path: filePath,
+        file_url: publicUrl,
+        status: 'pending',
+        reason: null,
+      },
+      { onConflict: 'profile_id' }
+    )
+    .select('status, reason, file_url')
+    .single();
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  res.json({ status: data?.status ?? 'pending', reason: data?.reason, file_url: data?.file_url ?? publicUrl });
+});
+
+r.get('/status', async (req, res) => {
+  const me = (req as any).userId as string;
+  const { data, error } = await supabase
+    .from('proofs')
+    .select('status, reason, file_url, updated_at, created_at')
+    .eq('profile_id', me)
+    .maybeSingle();
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (!data) {
+    return res.json({ status: 'not_submitted' });
+  }
+
+  res.json({
+    status: data.status,
+    reason: data.reason,
+    file_url: data.file_url,
+    updated_at: (data as any).updated_at ?? null,
+    created_at: (data as any).created_at ?? null,
+  });
+});
+
+export default r;

--- a/backend/src/routes/swipes.ts
+++ b/backend/src/routes/swipes.ts
@@ -8,16 +8,31 @@ r.use(auth);
 
 r.post('/', async (req, res) => {
   const me = (req as any).userId as string;
-  const { to_user, decision } = req.body || {};
-  if (!to_user || !['like', 'pass'].includes(decision)) {
-    return res.status(400).json({ error: 'bad payload' });
+  const body = req.body || {};
+
+  const toUser = typeof body.to_user === 'string' ? body.to_user.trim() : '';
+  const decision = typeof body.decision === 'string' ? body.decision : '';
+
+  const allowedDecisions = new Set(['like', 'pass']);
+  const uuidRegex = /^[0-9a-fA-F-]{32,36}$/;
+
+  if (!toUser || !uuidRegex.test(toUser)) {
+    return res.status(400).json({ error: 'invalid to_user' });
   }
 
-  const { error } = await supabase.from('swipes').insert([{ from_user: me, to_user, decision }]);
+  if (!allowedDecisions.has(decision)) {
+    return res.status(400).json({ error: 'decision must be like or pass' });
+  }
+
+  if (toUser === me) {
+    return res.status(400).json({ error: 'cannot swipe on yourself' });
+  }
+
+  const { error } = await supabase.from('swipes').insert([{ from_user: me, to_user: toUser, decision }]);
   if (error) return res.status(400).json({ error: error.message });
 
   let match = null;
-  if (decision === 'like') match = await createMatchIfMutual(me, to_user);
+  if (decision === 'like') match = await createMatchIfMutual(me, toUser);
 
   res.json({ ok: true, match });
 });

--- a/backend/src/utils/multipart.ts
+++ b/backend/src/utils/multipart.ts
@@ -1,0 +1,95 @@
+import { Request } from 'express';
+
+export interface MultipartFile {
+  filename: string;
+  contentType: string;
+  data: Buffer;
+  size: number;
+}
+
+export interface MultipartFormData {
+  fields: Record<string, string>;
+  files: Record<string, MultipartFile>;
+}
+
+function getBoundary(contentType: string): string | null {
+  const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
+  const boundary = boundaryMatch?.[1] || boundaryMatch?.[2];
+  if (!boundary) return null;
+  return `--${boundary}`;
+}
+
+export async function parseMultipartFormData(req: Request): Promise<MultipartFormData> {
+  const contentType = req.headers['content-type'];
+  if (!contentType || !contentType.includes('multipart/form-data')) {
+    throw new Error('content-type must be multipart/form-data');
+  }
+
+  const boundary = getBoundary(contentType);
+  if (!boundary) {
+    throw new Error('boundary not found');
+  }
+
+  const chunks: Buffer[] = [];
+  const requestStream: any = req;
+  for await (const chunk of requestStream) {
+    if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk));
+    } else {
+      chunks.push(chunk as Buffer);
+    }
+  }
+
+  const buffer = Buffer.concat(chunks);
+  const body = buffer.toString('binary');
+
+  const rawParts = body.split(boundary).slice(1, -1);
+
+  const fields: Record<string, string> = {};
+  const files: Record<string, MultipartFile> = {};
+
+  for (const rawPart of rawParts) {
+    if (!rawPart) continue;
+
+    let part = rawPart;
+    if (part.startsWith('\r\n')) part = part.slice(2);
+    if (part.endsWith('\r\n')) part = part.slice(0, -2);
+
+    const headerEndIndex = part.indexOf('\r\n\r\n');
+    if (headerEndIndex === -1) continue;
+
+    const headersText = part.slice(0, headerEndIndex);
+    let dataText = part.slice(headerEndIndex + 4);
+
+    if (dataText.endsWith('\r\n')) {
+      dataText = dataText.slice(0, -2);
+    }
+
+    const headerLines = headersText.split('\r\n').filter(Boolean);
+    const dispositionLine = headerLines.find(line => line.toLowerCase().startsWith('content-disposition'));
+    if (!dispositionLine) continue;
+
+    const nameMatch = dispositionLine.match(/name="([^"]+)"/i);
+    if (!nameMatch) continue;
+    const fieldName = nameMatch[1];
+
+    const filenameMatch = dispositionLine.match(/filename="([^"]*)"/i);
+    const contentTypeLine = headerLines.find(line => line.toLowerCase().startsWith('content-type'));
+    const detectedContentType = contentTypeLine ? contentTypeLine.split(':')[1].trim() : 'application/octet-stream';
+
+    const dataBuffer = Buffer.from(dataText, 'binary');
+
+    if (filenameMatch && filenameMatch[1]) {
+      files[fieldName] = {
+        filename: filenameMatch[1],
+        contentType: detectedContentType,
+        data: dataBuffer,
+        size: dataBuffer.length,
+      };
+    } else {
+      fields[fieldName] = dataBuffer.toString('utf8');
+    }
+  }
+
+  return { fields, files };
+}


### PR DESCRIPTION
## Summary
- add server-side validation for onboarding requests and swipe actions
- implement the proofs upload/status API using Supabase storage and a multipart parser
- register the proofs router and ignore node_modules via a gitignore

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dc2936c190832da1def490e09bd19b