### PR TITLE
fix: stabilize proof upload token handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+backend/node_modules/
+.env
+.env.*
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
 # mini-gymatch
+
+Aplicação composta por um backend em Node.js/Express e um app mobile em React Native (Expo) para gerenciamento do Gymatch.
+
+## Estrutura do projeto
+
+- `backend/` — API REST que integra com Supabase e valida comprovantes de matrícula usando IA.
+- `mobile/` — aplicativo Expo que consome a API.
+
+## Pré-requisitos
+
+- Node.js 18 ou superior e npm instalados.
+- Conta e projeto configurados no Supabase (com as tabelas esperadas pela API).
+- Chave de API da OpenAI caso deseje ativar a validação automática de comprovantes.
+- Expo CLI (via `npm install -g expo-cli`) ou uso dos comandos com `npx`.
+
+## Backend
+
+1. Instale as dependências:
+
+   ```bash
+   cd backend
+   npm install
+   ```
+
+2. Crie um arquivo `.env` na pasta `backend` com as variáveis necessárias:
+
+   ```bash
+   SUPABASE_URL=https://seu-projeto.supabase.co
+   SUPABASE_SERVICE_ROLE_KEY=chave_service_role
+   PORT=3000
+   OPENAI_API_KEY=sua_chave_openai # opcional, obrigatório apenas se quiser validação automática
+   GYM_PROOF_KEYWORDS=academia,mensalidade,matrícula # opcional, lista separada por vírgula
+   PROOF_VALIDATION_MODEL=gpt-4.1-mini # opcional
+   OPENAI_PROOF_ENDPOINT=https://api.openai.com/v1/responses # opcional
+   ```
+
+   > Se `OPENAI_API_KEY` não for configurada, a API receberá o comprovante e manterá o status como `pending` para revisão manual.
+
+3. Execute o servidor em modo desenvolvimento:
+
+   ```bash
+   npm run dev
+   ```
+
+   A API ficará disponível em `http://localhost:3000`, com os endpoints expostos sob `/api/...` (ex.: `http://localhost:3000/api/proofs`).
+
+## Mobile (Expo)
+
+1. Instale as dependências do app:
+
+   ```bash
+   cd mobile
+   npm install
+   ```
+
+2. Configure a URL da API criando um arquivo `.env` na pasta `mobile` (ou exportando a variável no ambiente) com a variável `EXPO_PUBLIC_API_URL` apontando para o backend. Exemplos:
+
+   ```bash
+   EXPO_PUBLIC_API_URL=http://localhost:3000/api           # iOS simulador
+   EXPO_PUBLIC_API_URL=http://10.0.2.2:3000/api            # Android emulador
+   EXPO_PUBLIC_API_URL=http://192.168.0.10:3000/api        # Dispositivo físico
+   ```
+
+   > Em emuladores Android, pode ser necessário rodar `adb reverse tcp:3000 tcp:3000` para que o app acesse o backend local.
+
+3. Inicie o projeto Expo:
+
+   ```bash
+   npm run start
+   ```
+
+   Escolha a plataforma (Android, iOS ou web) no menu interativo do Expo.
+
+## Dicas adicionais
+
+- Mantenha o backend rodando antes de abrir o app mobile para evitar erros de conexão.
+- O endpoint `GET /health` confirma se o servidor está ativo e `GET /health/db` testa a comunicação com o Supabase.
+- Ajuste os caminhos padrão no arquivo `mobile/src/api/client.ts` caso prefira definir a URL diretamente no código em vez de usar variável de ambiente.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import profiles from './routes/profiles';
 import feed from './routes/feed';
 import swipes from './routes/swipes';
 import matches from './routes/matches';
+import proofs from './routes/proofs';
 
 const app = express();
 app.use(cors());
@@ -30,4 +31,5 @@ app.use('/api/profiles', profiles);
 app.use('/api/feed', feed);
 app.use('/api/swipes', swipes);
 app.use('/api/matches', matches);
+app.use('/api/proofs', proofs);
 app.listen(port, () => console.log(`API on http://localhost:${port}`));

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { supabase } from '../services/db';
 
 export async function auth(req: Request, res: Response, next: NextFunction) {
   const token = req.header('x-auth-token');
-  if (!token) return res.status(401).json({ error: 'missing token' });
+  if (!token) return res.status(401).json({ error: 'unauthorized', detail: 'missing token' });
 
   const { data, error } = await supabase
     .from('profiles')
@@ -11,7 +11,7 @@ export async function auth(req: Request, res: Response, next: NextFunction) {
     .eq('auth_token', token)
     .single();
 
-  if (error || !data) return res.status(401).json({ error: 'invalid token' });
+  if (error || !data) return res.status(401).json({ error: 'unauthorized', detail: 'invalid token' });
   (req as any).userId = data.id;
   next();
 }

--- a/backend/src/routes/profiles.ts
+++ b/backend/src/routes/profiles.ts
@@ -3,16 +3,134 @@ import { supabase } from '../services/db';
 import { randomUUID } from 'crypto';
 import { auth } from '../middleware/auth';
 
+type OnboardPayload = {
+  email?: string;
+  name: string;
+  birthdate?: string | null;
+  gender: 'male' | 'female' | 'other';
+  show_me: 'male' | 'female' | 'everyone';
+  bio?: string | null;
+  interests?: string[] | null;
+  photo_url?: string | null;
+};
+
+function parseOnboardPayload(body: any): OnboardPayload {
+  if (!body || typeof body !== 'object') {
+    throw new Error('invalid payload');
+  }
+
+  const errors: string[] = [];
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (name.length < 2) {
+    errors.push('name must have at least 2 characters');
+  }
+
+  const emailRaw = typeof body.email === 'string' ? body.email.trim() : '';
+  let email: string | undefined;
+  if (emailRaw) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(emailRaw.toLowerCase())) {
+      errors.push('email must be valid');
+    } else {
+      email = emailRaw.toLowerCase();
+    }
+  }
+
+  const allowedGenders = new Set(['male', 'female', 'other']);
+  const allowedShow = new Set(['male', 'female', 'everyone']);
+
+  const gender = typeof body.gender === 'string' ? (body.gender as string) : '';
+  if (!allowedGenders.has(gender)) {
+    errors.push('gender must be one of male, female or other');
+  }
+
+  const showMe = typeof body.show_me === 'string' ? (body.show_me as string) : '';
+  if (!allowedShow.has(showMe)) {
+    errors.push('show_me must be one of male, female or everyone');
+  }
+
+  let birthdate: string | null | undefined = undefined;
+  if (body.birthdate != null) {
+    if (typeof body.birthdate !== 'string' || !body.birthdate.trim()) {
+      errors.push('birthdate must be a string');
+    } else {
+      birthdate = body.birthdate.trim();
+    }
+  }
+
+  let bio: string | null | undefined = undefined;
+  if (body.bio != null) {
+    if (typeof body.bio !== 'string') {
+      errors.push('bio must be a string');
+    } else if (body.bio.length > 500) {
+      errors.push('bio must be at most 500 characters');
+    } else {
+      bio = body.bio;
+    }
+  }
+
+  let interests: string[] | null | undefined = undefined;
+  if (body.interests != null) {
+    if (!Array.isArray(body.interests)) {
+      errors.push('interests must be an array of strings');
+    } else {
+      const parsedInterests = body.interests.filter((item: any) => typeof item === 'string' && item.trim());
+      interests = parsedInterests.length ? parsedInterests : null;
+    }
+  }
+
+  let photoUrl: string | null | undefined = undefined;
+  if (body.photo_url != null) {
+    if (typeof body.photo_url !== 'string' || !body.photo_url.trim()) {
+      errors.push('photo_url must be a string');
+    } else {
+      photoUrl = body.photo_url.trim();
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(errors[0]);
+  }
+
+  return {
+    email,
+    name,
+    birthdate: birthdate ?? null,
+    gender: gender as OnboardPayload['gender'],
+    show_me: showMe as OnboardPayload['show_me'],
+    bio: bio ?? null,
+    interests: interests ?? null,
+    photo_url: photoUrl ?? null,
+  };
+}
+
 const r = Router();
 
 r.post('/onboard', async (req, res) => {
-  const { email, name, birthdate, gender, show_me, bio, interests, photo_url } = req.body || {};
-  if (!name) return res.status(400).json({ error: 'name required' });
+  let payload: OnboardPayload;
+  try {
+    payload = parseOnboardPayload(req.body);
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || 'invalid payload' });
+  }
 
   const token = randomUUID();
   const { data, error } = await supabase
     .from('profiles')
-    .insert([{ auth_token: token, email, name, birthdate, gender, show_me, bio, interests, photo_url }])
+    .insert([
+      {
+        auth_token: token,
+        email: payload.email,
+        name: payload.name,
+        birthdate: payload.birthdate,
+        gender: payload.gender,
+        show_me: payload.show_me,
+        bio: payload.bio,
+        interests: payload.interests,
+        photo_url: payload.photo_url,
+      },
+    ])
     .select('*')
     .single();
 

--- a/backend/src/routes/proofs.ts
+++ b/backend/src/routes/proofs.ts
@@ -1,0 +1,205 @@
+import { Router } from 'express';
+import { auth } from '../middleware/auth';
+import { parseMultipartFormData } from '../utils/multipart';
+import { supabase } from '../services/db';
+import {
+  ProofValidationDisabledError,
+  ProofValidationOutcome,
+  validateGymProofImage,
+} from '../services/proofValidation';
+
+const MAX_UPLOAD_SIZE = 6 * 1024 * 1024; // 6MB
+const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']);
+
+function sanitizeFilename(filename: string): string {
+  return filename
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+const router = Router();
+router.use(auth);
+
+type ProofRecord = {
+  status: 'pending' | 'approved' | 'rejected';
+  reason: string | null;
+  file_url: string | null;
+  ocr_text: string | null;
+};
+
+async function upsertProof(userId: string, payload: Partial<ProofRecord>): Promise<ProofRecord> {
+  const { data, error } = await supabase
+    .from('proofs')
+    .upsert(
+      {
+        user_id: userId,
+        ...payload,
+      },
+      { onConflict: 'user_id' }
+    )
+    .select('status, reason, file_url, ocr_text')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return {
+    status: (data?.status as ProofRecord['status']) ?? 'pending',
+    reason: (data?.reason as ProofRecord['reason']) ?? null,
+    file_url: (data?.file_url as ProofRecord['file_url']) ?? null,
+    ocr_text: (data?.ocr_text as ProofRecord['ocr_text']) ?? null,
+  };
+}
+
+function buildReasonFromAi(validation: ProofValidationOutcome): string | null {
+  const pieces: string[] = [];
+
+  if (validation.reason) {
+    pieces.push(validation.reason);
+  }
+
+  if (validation.matchedKeywords.length) {
+    pieces.push(`Palavras-chave encontradas: ${validation.matchedKeywords.join(', ')}.`);
+  }
+
+  if (typeof validation.confidence === 'number') {
+    pieces.push(`Confiança IA: ${(validation.confidence * 100).toFixed(0)}%.`);
+  }
+
+  if (!pieces.length) {
+    pieces.push(
+      validation.approved
+        ? 'Documento aprovado automaticamente pela IA com base na análise do comprovante.'
+        : 'A IA não encontrou evidências suficientes na imagem para confirmar a matrícula na academia.'
+    );
+
+    if (!validation.approved && !validation.matchedKeywords.length) {
+      pieces.push('Nenhuma palavra-chave relevante foi localizada.');
+    }
+  }
+
+  return pieces.join(' ').trim() || null;
+}
+
+router.post('/', async (req, res) => {
+  let form;
+  try {
+    form = await parseMultipartFormData(req);
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || 'could not parse form-data' });
+  }
+
+  const file = form.files['file'];
+  if (!file) {
+    return res.status(400).json({ error: 'missing file field' });
+  }
+
+  if (file.size <= 0) {
+    return res.status(400).json({ error: 'file is empty' });
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE) {
+    return res.status(400).json({ error: 'file too large (limit 6MB)' });
+  }
+
+  const mime = file.contentType.toLowerCase();
+  if (!ALLOWED_MIME.has(mime)) {
+    return res.status(400).json({ error: 'unsupported file type' });
+  }
+
+  const me = (req as any).userId as string;
+  const timestamp = Date.now();
+  const safeName = sanitizeFilename(file.filename || 'proof');
+  const filePath = `${me}/${timestamp}-${safeName}`;
+
+  const storage = supabase.storage.from('proofs');
+  const { error: uploadError } = await storage.upload(filePath, file.data, {
+    contentType: mime,
+    upsert: true,
+  });
+
+  if (uploadError) {
+    return res.status(400).json({ error: uploadError.message });
+  }
+
+  const { data: publicUrlData } = storage.getPublicUrl(filePath);
+  const publicUrl = publicUrlData?.publicUrl ?? null;
+
+  let record: ProofRecord;
+  try {
+    record = await upsertProof(me, {
+      file_url: publicUrl,
+      status: 'pending',
+      reason: null,
+      ocr_text: null,
+    });
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || 'Não foi possível salvar o comprovante' });
+  }
+
+  let status = record.status;
+  let reason = record.reason;
+  const fileUrl = record.file_url ?? publicUrl;
+
+  try {
+    const validation = await validateGymProofImage(file.data, mime, { profileId: me });
+    status = validation.approved ? 'approved' : 'rejected';
+    reason = buildReasonFromAi(validation);
+
+    await supabase
+      .from('proofs')
+      .update({
+        status,
+        reason,
+        ocr_text: validation.matchedKeywords.join(', ') || null,
+      })
+      .eq('user_id', me);
+  } catch (err) {
+    if (err instanceof ProofValidationDisabledError) {
+      status = 'pending';
+      reason =
+        'Comprovante recebido. A validação automática está desativada e será concluída manualmente em breve.';
+    } else {
+      console.error('proof-validation:error', err);
+      status = 'pending';
+      reason =
+        'Comprovante recebido, mas ocorreu um erro na validação automática. Nossa equipe fará a revisão manual.';
+    }
+
+    await supabase
+      .from('proofs')
+      .update({ status, reason })
+      .eq('user_id', me);
+  }
+
+  res.json({ status, reason, file_url: fileUrl });
+});
+
+router.get('/status', async (req, res) => {
+  const me = (req as any).userId as string;
+  const { data, error } = await supabase
+    .from('proofs')
+    .select('status, reason, file_url, updated_at, created_at')
+    .eq('user_id', me)
+    .maybeSingle();
+
+  if (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (!data) {
+    return res.json({ status: 'not_submitted' });
+  }
+
+  res.json({
+    status: data.status,
+    reason: data.reason,
+    file_url: data.file_url,
+    updated_at: (data as any).updated_at ?? null,
+    created_at: (data as any).created_at ?? null,
+  });
+});
+
+export default router;

--- a/backend/src/routes/swipes.ts
+++ b/backend/src/routes/swipes.ts
@@ -8,16 +8,31 @@ r.use(auth);
 
 r.post('/', async (req, res) => {
   const me = (req as any).userId as string;
-  const { to_user, decision } = req.body || {};
-  if (!to_user || !['like', 'pass'].includes(decision)) {
-    return res.status(400).json({ error: 'bad payload' });
+  const body = req.body || {};
+
+  const toUser = typeof body.to_user === 'string' ? body.to_user.trim() : '';
+  const decision = typeof body.decision === 'string' ? body.decision : '';
+
+  const allowedDecisions = new Set(['like', 'pass']);
+  const uuidRegex = /^[0-9a-fA-F-]{32,36}$/;
+
+  if (!toUser || !uuidRegex.test(toUser)) {
+    return res.status(400).json({ error: 'invalid to_user' });
   }
 
-  const { error } = await supabase.from('swipes').insert([{ from_user: me, to_user, decision }]);
+  if (!allowedDecisions.has(decision)) {
+    return res.status(400).json({ error: 'decision must be like or pass' });
+  }
+
+  if (toUser === me) {
+    return res.status(400).json({ error: 'cannot swipe on yourself' });
+  }
+
+  const { error } = await supabase.from('swipes').insert([{ from_user: me, to_user: toUser, decision }]);
   if (error) return res.status(400).json({ error: error.message });
 
   let match = null;
-  if (decision === 'like') match = await createMatchIfMutual(me, to_user);
+  if (decision === 'like') match = await createMatchIfMutual(me, toUser);
 
   res.json({ ok: true, match });
 });

--- a/backend/src/services/proofValidation.ts
+++ b/backend/src/services/proofValidation.ts
@@ -1,0 +1,182 @@
+import https from 'https';
+
+const DEFAULT_KEYWORDS = (process.env.GYM_PROOF_KEYWORDS ||
+  'academia, matrícula, matricula, aluno, mensalidade, plano, contrato, pagamento, recibo, unidade')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const MODEL = process.env.PROOF_VALIDATION_MODEL || 'gpt-4.1-mini';
+const ENDPOINT = process.env.OPENAI_PROOF_ENDPOINT || 'https://api.openai.com/v1/responses';
+
+export class ProofValidationDisabledError extends Error {
+  constructor(message = 'AI proof validation is not configured') {
+    super(message);
+    this.name = 'ProofValidationDisabledError';
+  }
+}
+
+export type ProofValidationOutcome = {
+  approved: boolean;
+  matchedKeywords: string[];
+  reason: string;
+  confidence?: number;
+};
+
+async function callOpenAI(payload: unknown, apiKey: string): Promise<any> {
+  const body = JSON.stringify(payload);
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      ENDPOINT,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf-8');
+
+          if ((response.statusCode || 500) >= 400) {
+            return reject(new Error(`OpenAI API error (${response.statusCode}): ${text}`));
+          }
+
+          try {
+            resolve(JSON.parse(text));
+          } catch (err: any) {
+            reject(new Error(`Could not parse OpenAI response: ${err?.message || 'unknown error'}`));
+          }
+        });
+      }
+    );
+
+    request.on('error', reject);
+    request.write(body);
+    request.end();
+  });
+}
+
+export async function validateGymProofImage(
+  fileBuffer: Buffer,
+  mimeType: string,
+  options?: { keywords?: string[]; profileId?: string }
+): Promise<ProofValidationOutcome> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new ProofValidationDisabledError();
+  }
+
+  const keywords = (options?.keywords || DEFAULT_KEYWORDS).map((value) => value.trim()).filter(Boolean);
+
+  if (!keywords.length) {
+    throw new Error('No keywords configured for proof validation');
+  }
+
+  const base64 = fileBuffer.toString('base64');
+  const imageUrl = `data:${mimeType};base64,${base64}`;
+  const profileId = options?.profileId?.trim();
+
+  const schema = {
+    name: 'GymProofValidation',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        approved: { type: 'boolean' },
+        matched_keywords: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        reason: { type: 'string' },
+        confidence: { type: 'number', minimum: 0, maximum: 1 },
+      },
+      required: ['approved', 'matched_keywords', 'reason'],
+    },
+    strict: true,
+  } as const;
+
+  const payload = {
+    model: MODEL,
+    max_output_tokens: 300,
+    input: [
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: [
+              'Você é um assistente especializado em validar comprovantes de matrícula de academias.',
+              'Aprove somente se o documento trouxer evidências claras (texto visível) que a pessoa está matriculada.',
+              'Use o contexto para identificar sinônimos ou abreviações das palavras-chave informadas.',
+              'Retorne sempre um JSON compatível com o schema informado.',
+              profileId ? `ID do perfil em análise: ${profileId}.` : '',
+            ]
+              .filter(Boolean)
+              .join(' '),
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_text',
+            text: `Analise o comprovante e indique se ele confirma a matrícula na academia. Palavras-chave alvo: ${keywords.join(
+              ', '
+            )}.`,
+          },
+          {
+            type: 'input_text',
+            text: 'Informe também quais palavras-chave (ou variações) foram encontradas, um motivo curto e um nível de confiança.',
+          },
+          {
+            type: 'input_image',
+            image_url: imageUrl,
+          },
+        ],
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: schema,
+    },
+  };
+
+  const response = await callOpenAI(payload, apiKey);
+
+  let parsed: any = null;
+  const output = response?.output || [];
+  for (const block of output || []) {
+    for (const piece of block?.content || []) {
+      if (piece?.type === 'json_schema' && piece?.json) {
+        parsed = piece.json;
+        break;
+      }
+    }
+    if (parsed) break;
+  }
+
+  if (!parsed) {
+    throw new Error('Could not parse AI response for proof validation');
+  }
+
+  const approved = Boolean(parsed.approved);
+  const reason = typeof parsed.reason === 'string' && parsed.reason.trim().length > 0 ? parsed.reason.trim() : '';
+  const matchedKeywords = Array.isArray(parsed.matched_keywords)
+    ? parsed.matched_keywords.map((item: any) => String(item).trim()).filter(Boolean)
+    : [];
+  const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : undefined;
+
+  return {
+    approved,
+    matchedKeywords,
+    reason,
+    confidence,
+  };
+}

--- a/backend/src/utils/multipart.ts
+++ b/backend/src/utils/multipart.ts
@@ -1,0 +1,95 @@
+import { Request } from 'express';
+
+export interface MultipartFile {
+  filename: string;
+  contentType: string;
+  data: Buffer;
+  size: number;
+}
+
+export interface MultipartFormData {
+  fields: Record<string, string>;
+  files: Record<string, MultipartFile>;
+}
+
+function getBoundary(contentType: string): string | null {
+  const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
+  const boundary = boundaryMatch?.[1] || boundaryMatch?.[2];
+  if (!boundary) return null;
+  return `--${boundary}`;
+}
+
+export async function parseMultipartFormData(req: Request): Promise<MultipartFormData> {
+  const contentType = req.headers['content-type'];
+  if (!contentType || !contentType.includes('multipart/form-data')) {
+    throw new Error('content-type must be multipart/form-data');
+  }
+
+  const boundary = getBoundary(contentType);
+  if (!boundary) {
+    throw new Error('boundary not found');
+  }
+
+  const chunks: Buffer[] = [];
+  const requestStream: any = req;
+  for await (const chunk of requestStream) {
+    if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk));
+    } else {
+      chunks.push(chunk as Buffer);
+    }
+  }
+
+  const buffer = Buffer.concat(chunks);
+  const body = buffer.toString('binary');
+
+  const rawParts = body.split(boundary).slice(1, -1);
+
+  const fields: Record<string, string> = {};
+  const files: Record<string, MultipartFile> = {};
+
+  for (const rawPart of rawParts) {
+    if (!rawPart) continue;
+
+    let part = rawPart;
+    if (part.startsWith('\r\n')) part = part.slice(2);
+    if (part.endsWith('\r\n')) part = part.slice(0, -2);
+
+    const headerEndIndex = part.indexOf('\r\n\r\n');
+    if (headerEndIndex === -1) continue;
+
+    const headersText = part.slice(0, headerEndIndex);
+    let dataText = part.slice(headerEndIndex + 4);
+
+    if (dataText.endsWith('\r\n')) {
+      dataText = dataText.slice(0, -2);
+    }
+
+    const headerLines = headersText.split('\r\n').filter(Boolean);
+    const dispositionLine = headerLines.find(line => line.toLowerCase().startsWith('content-disposition'));
+    if (!dispositionLine) continue;
+
+    const nameMatch = dispositionLine.match(/name="([^"]+)"/i);
+    if (!nameMatch) continue;
+    const fieldName = nameMatch[1];
+
+    const filenameMatch = dispositionLine.match(/filename="([^"]*)"/i);
+    const contentTypeLine = headerLines.find(line => line.toLowerCase().startsWith('content-type'));
+    const detectedContentType = contentTypeLine ? contentTypeLine.split(':')[1].trim() : 'application/octet-stream';
+
+    const dataBuffer = Buffer.from(dataText, 'binary');
+
+    if (filenameMatch && filenameMatch[1]) {
+      files[fieldName] = {
+        filename: filenameMatch[1],
+        contentType: detectedContentType,
+        data: dataBuffer,
+        size: dataBuffer.length,
+      };
+    } else {
+      fields[fieldName] = dataBuffer.toString('utf8');
+    }
+  }
+
+  return { fields, files };
+}

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <NavigationContainer>
-        <Stack.Navigator initialRouteName="Onboarding">
+        <Stack.Navigator id={undefined} initialRouteName="Onboarding">
           <Stack.Screen name="Onboarding" component={Onboarding} />
           <Stack.Screen name="Swipe" component={Swipe} />
           <Stack.Screen name="Matches" component={Matches} />

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -7,7 +7,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
  * - iOS simulador:   http://localhost:3000/api
  * - Dispositivo físico: http://SEU_IP_LAN:3000/api  (ex.: http://192.168.0.14:3000/api)
  */
-const BASE_URL = "http://192.168.2.105:3000/api"; // ajuste aqui
+const DEFAULT_URL = "http://192.168.2.105:3000/api"; // ajuste aqui
+const BASE_URL = (process.env.EXPO_PUBLIC_API_URL || DEFAULT_URL).replace(/\/$/, "");
 
 export const api = axios.create({ baseURL: BASE_URL });
 

--- a/mobile/src/api/screens/ProofUpload.tsx
+++ b/mobile/src/api/screens/ProofUpload.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { View, Button, Text, Alert, Image, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as ImagePicker from "expo-image-picker";
 import { api } from "../client";
 import { colors, spacing } from "../theme";
@@ -10,14 +11,53 @@ export default function ProofUpload() {
   const [status, setStatus] = useState<any>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const missingTokenMessage = "Token não encontrado. Faça o onboarding novamente.";
+
+  const allowedMimes = useMemo(
+    () => new Set(["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"]),
+    []
+  );
+
+  useEffect(() => {
+    check(true);
+  }, []);
+
+  async function ensureToken(options: { silent?: boolean } = {}) {
+    const stored = await AsyncStorage.getItem("token");
+    if (!stored) {
+      setLastError(missingTokenMessage);
+      if (!options.silent) {
+        Alert.alert("Atenção", missingTokenMessage);
+      }
+      return null;
+    }
+    return stored;
+  }
 
   async function pickAndSend() {
+    const token = await ensureToken();
+    if (!token) return;
+
     const res = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images, allowsMultipleSelection: false, quality: 1,
     });
     if (res.canceled) return;
 
     const asset = res.assets[0];
+    const mimeType = asset.mimeType || "";
+    const fileSize = asset.fileSize ?? 0;
+
+    if (mimeType && !allowedMimes.has(mimeType.toLowerCase())) {
+      Alert.alert("Formato inválido", "Envie uma imagem JPEG, PNG, WEBP ou HEIC.");
+      return;
+    }
+
+    if (fileSize > 0 && fileSize > 6 * 1024 * 1024) {
+      Alert.alert("Arquivo muito grande", "O limite é de 6MB.");
+      return;
+    }
+
     setPreview(asset.uri);
     const file: RNFile = {
       uri: asset.uri,
@@ -30,19 +70,67 @@ export default function ProofUpload() {
 
     try {
       setBusy(true);
-      const { data } = await api.post("/proofs", form, { headers: { "Content-Type": "multipart/form-data" } });
+      setLastError(null);
+      const { data } = await api.post("/proofs", form, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+          "x-auth-token": token,
+        },
+      });
       setStatus(data);
       Alert.alert("Enviado!", `Status: ${data.status}`);
     } catch (e: any) {
-      Alert.alert("Erro", e?.response?.data?.error || e.message);
+      const statusCode = e?.response?.status;
+      const message = e?.response?.data?.error || e.message;
+      if (statusCode === 401) {
+        const detail = e?.response?.data?.detail;
+        const friendly = "Token inválido. Refazendo o onboarding você gera um novo.";
+        setLastError(friendly);
+        if (detail === "invalid token") {
+          await AsyncStorage.removeItem("token");
+        }
+        Alert.alert("Sessão expirada", friendly);
+        setStatus(null);
+      } else {
+        setLastError(message);
+        Alert.alert("Erro", message || "Não foi possível enviar o comprovante");
+      }
     } finally {
       setBusy(false);
     }
   }
 
-  async function check() {
-    const { data } = await api.get("/proofs/status");
-    setStatus(data);
+  async function check(silentMissingToken = false) {
+    const token = await ensureToken({ silent: silentMissingToken });
+    if (!token) return;
+
+    try {
+      const { data } = await api.get("/proofs/status", {
+        headers: {
+          "x-auth-token": token,
+        },
+      });
+      setStatus(data);
+      setLastError(null);
+    } catch (e: any) {
+      const statusCode = e?.response?.status;
+      const message = e?.response?.data?.error || e.message;
+      if (statusCode === 401) {
+        const detail = e?.response?.data?.detail;
+        const friendly = "Token inválido. Refazendo o onboarding você gera um novo.";
+        setLastError(friendly);
+        if (detail === "invalid token") {
+          await AsyncStorage.removeItem("token");
+        }
+        setStatus(null);
+        if (!silentMissingToken) {
+          Alert.alert("Sessão expirada", friendly);
+        }
+      } else {
+        setLastError(message);
+        Alert.alert("Erro", message || "Não foi possível consultar o status");
+      }
+    }
   }
 
   return (
@@ -53,12 +141,13 @@ export default function ProofUpload() {
 
       <View style={{ gap: spacing(1) }}>
         <Button title={busy ? "Enviando..." : "Selecionar e enviar"} onPress={pickAndSend} disabled={busy} />
-        <Button title="Ver status" onPress={check} />
+        <Button title="Ver status" onPress={() => check()} />
       </View>
 
       <View style={{ marginTop: spacing(2), gap: 6 }}>
         <Text style={styles.label}>Status: <Text style={styles.value}>{status?.status ?? "-"}</Text></Text>
         <Text style={styles.label}>Motivo: <Text style={styles.value}>{status?.reason ?? "-"}</Text></Text>
+        {lastError ? <Text style={[styles.label, { color: colors.warn }]}>Último erro: {lastError}</Text> : null}
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- garantir que as requisições de upload e status do comprovante enviem sempre o cabeçalho x-auth-token
- preservar o token salvo quando ocorrer 401 que não indicam token inválido, evitando derrubar o restante do app

## Testing
- cd mobile && npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dc2936c190832da1def490e09bd19b