### PR TITLE
Fix auth middleware to expose user object for proofs routes

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -12,6 +12,10 @@ export async function auth(req: Request, res: Response, next: NextFunction) {
     .single();
 
   if (error || !data) return res.status(401).json({ error: 'unauthorized', detail: 'invalid token' });
+
+  // Mantemos a propriedade `userId` para rotas existentes e também expomos
+  // `user.id` para compatibilidade com handlers que esperam essa estrutura.
   (req as any).userId = data.id;
+  (req as any).user = { id: data.id };
   next();
 }


### PR DESCRIPTION
## Summary
- expose a user object on the request in the auth middleware to match expectations from proofs routes
- retain the existing userId assignment to avoid regressions on other endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca4552dd4832daf0a0c71affadafe